### PR TITLE
Поддержка тензоров в качестве входа

### DIFF
--- a/src/inference/utils.py
+++ b/src/inference/utils.py
@@ -101,7 +101,7 @@ def create_list_images(input):
         else:
             input_is_correct = False
     if not input_is_correct:
-        raise ValueError("Wrong path to image or to directory with images")
+        raise ValueError('Wrong path to image or to directory with images')
     return images
 
 
@@ -109,11 +109,11 @@ def check_correct_input(len_values):
     ideal = len_values[0]
     for len in len_values:
         if len != ideal:
-            raise ValueError("Mismatch batch sizes for different input layers")
+            raise ValueError('Mismatch batch sizes for different input layers')
 
 
 def parse_tensors(filename):
-    with open(filename, "r") as file:
+    with open(filename, 'r') as file:
         input = file.readlines()
     input = [line.strip() for line in input]
     shape = [int(number) for number in input[0].split(';')]


### PR DESCRIPTION
# Обновления
## Что добавлено?
- На вход моделям могут подаваться тензора
## Как на вход подать тензор?
- Тензора для одного слоя описываются в формате `csv`
  В первой строке описывается размерность входного слоя в формате 
  `batch_size;dim1;dim2;...;dimN`
  На следующих строках описываются значения тензоров в формате
  `value1;value2;value3;...;valueM`
  Всего значений должно быть `batch_szie * dim1 * dim2 * ... * dimN`
- Тензора описываются для одного слоя. В каждом файле должны находится тензора сразу для всей пачки (batch size).
  Например, если у нас 2 входа, которые принимают тензора и размер пачки равен 4. То необходимо создать 2 файла, в которых будут описываться по 4 тензора для каждого слоя.
- Размерности всех тензоров в одном файле одинаковые
- Если количество тензоров меньше размера пачки, недостающие тензора будут заполнены копиями входных тензоров
- Если количество тензоров больше размера пачки, то количество тензоров должно быть кратно размеру пачки
